### PR TITLE
Add links to organizer and submitter guides

### DIFF
--- a/views/index.slim
+++ b/views/index.slim
@@ -126,6 +126,11 @@ html[lang="en"]
                 | •
                 a<> href="https://guide.biohackrxiv.org" Journal Guidelines
               p
+                | Guides:
+                a<> href="https://index.biohackrxiv.org/for-submitters/" For Paper Submitters
+                | •
+                a<> href="https://index.biohackrxiv.org/for-organizers/" For Event Organizers
+              p
                 | Have an issue?
                 a<> href="mailto:biohackrxiv@googlegroups.com" Contact us
       footer


### PR DESCRIPTION
## Summary

- Adds a "Guides" line to the footer links on the preview page, linking to:
  - [For Paper Submitters](https://index.biohackrxiv.org/for-submitters/) 
  - [For Event Organizers](https://index.biohackrxiv.org/for-organizers/)

These guide pages are being added in a companion PR: https://github.com/biohackrxiv/bhxiv-index/pull/8

## Test plan

- [ ] Verify the new links render correctly on the preview page
- [ ] Merge after the companion bhxiv-index PR is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)